### PR TITLE
Fix duplicate inputForm declaration in JavaScript

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,9 +503,6 @@
 
 
             // Get references to output elements in the certificate
-            const inputForm = document.getElementById('inputForm');
-            const certificateDisplay = document.getElementById('certificateDisplay');
-            const actionButtonsContainer = document.querySelector('.action-buttons');
             const outputPlayerName = document.getElementById('outputPlayerName');
             const outputAwardName = document.getElementById('outputAwardName');
             const outputCoachName = document.getElementById('outputCoachName');


### PR DESCRIPTION
Removed duplicate const declarations for inputForm, certificateDisplay, and actionButtonsContainer that were causing JavaScript errors. These variables were already declared earlier in the DOMContentLoaded event listener.