### PR TITLE
Fix vercel.json regex patterns for header source

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -17,7 +17,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(png|jpg|jpeg|gif|svg|ico|webp))",
+      "source": "/:path*.(png|jpg|jpeg|gif|svg|ico|webp)",
       "headers": [
         {
           "key": "Cache-Control",
@@ -26,7 +26,7 @@
       ]
     },
     {
-      "source": "/(.*\\.(css|js))",
+      "source": "/:path*.(css|js)",
       "headers": [
         {
           "key": "Cache-Control",
@@ -35,7 +35,7 @@
       ]
     },
     {
-      "source": "/(.*)",
+      "source": "/:path*",
       "headers": [
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
Changed from invalid regex patterns to Vercel's path parameter syntax:
- Old: /(.*\.(png|jpg|...))
- New: /:path*.(png|jpg|...)

This fixes the 'invalid source pattern' deployment error.